### PR TITLE
fix(wappalyzer-antenna): not detecting on some websites

### DIFF
--- a/src/drivers/webextension/js/antenna-content.js
+++ b/src/drivers/webextension/js/antenna-content.js
@@ -8,15 +8,12 @@ function mountAntenna(url) {
   return new Promise((resolve, reject) => {
     script.onerror = reject
 
-    window.addEventListener(
-      'message',
-      ({ data }) => {
-        if (!data.wappalyzerAntenna) return
+    window.addEventListener('message', function onScriptReady({ data }) {
+      if (!data.wappalyzerAntenna) return
 
-        resolve()
-      },
-      { once: true }
-    )
+      resolve()
+      window.removeEventListener('message', onScriptReady)
+    })
 
     script.setAttribute('src', chrome.runtime.getURL(url))
 


### PR DESCRIPTION
## Bug Description

Some websites like [small-games.info](https://small-games.info), calling `postMessage` before `anttena.js` script and this
causes `await injectScript("js/antenna.js")` to not resolve and wait!

Closes #1 